### PR TITLE
Small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 __pycache__
+.ropeproject
+.idea/

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Monitor resource used by running containers
 ```
 
 or
+
 ```
 # git clone git@github.com:docker/docker-py.git
 # cd docker-py
@@ -62,7 +63,7 @@ or
 # cp *.py /etc/zabbix
 # chowm -R zabbix /etc/zabbix/
 # chmod u+x /etc/zabbix/*.py
-# echo "Defaults:username !requiretty" >> /etc/sudoers
+# echo 'Defaults:username !requiretty' >> /etc/sudoers
 # echo "zabbix ALL=NOPASSWD: /etc/zabbix/docker_stats.py -l" >> /etc/sudoers
 # echo "*/5 * * * *   root /etc/zabbix/docker_stats.py" > /etc/cron.d/docker-zabbix
 # apt-get install zabbix-agent

--- a/docker_stats.py
+++ b/docker_stats.py
@@ -9,22 +9,15 @@ parser.add_option('-l', action="store_true", dest="list", default=False)
 # Docker access
 docker_service = DockerService.DockerService(opts.url)
 containerslist = docker_service.list_containers()
-if opts.list == True :
-    first = 1;
-    print "{\n";
-    print "\t\"data\":[\n";
-
+if opts.list == True:
+    import json
+    con_list=[]
     for container in containerslist:
-
-        if first == 0:
-            print ",\n"
-        first = 0
         Name = container['Names']
-        #print "\t{",  "\"{#CONTAINERID}\":\"",container['Id'],"\",","\"{#name}\":\"",container['Id'],"\"}"
-        print "\t{",  "\"{#NAME}\":\"",str(Name)[4:-2],"\"}"
-
-    print "\n\t]\n"
-    print "}\n"  
+        con_list.append({'{#NAME}':str(Name)[4:-2]})
+    con_dict = {}
+    con_dict['data'] = con_list
+    print(json.dumps(con_dict))
 else :
     for container in containerslist:
         Name = container['Names']


### PR DESCRIPTION
1. In bash it is better to use an apostrophe instead of quotation marks because for example on CentOS and MacOS generate quotes the following issue: <code>-bash: !requiretty": event not found</code>.
2. Slightly simplified the creation of the array of found containers. Probably not necessary in the formation of a json document with chain print and checks the number of elements in it :)
